### PR TITLE
Add digitalPinToInterrupt macro to Rambo pins_arduino.h

### DIFF
--- a/variants/rambo/pins_arduino.h
+++ b/variants/rambo/pins_arduino.h
@@ -83,6 +83,8 @@ static const uint8_t A15 = 69;
                                 ( (((p) >= 62) && ((p) <= 69)) ? ((p) - 62) : \
                                 0 ) ) ) ) ) )
 
+#define digitalPinToInterrupt(p) ((p) == 2 ? 0 : ((p) == 3 ? 1 : ((p) >= 18 && (p) <= 21 ? 23 - (p) : NOT_AN_INTERRUPT)))
+
 #ifdef ARDUINO_MAIN
 
 const uint16_t PROGMEM port_to_mode_PGM[] = {


### PR DESCRIPTION
The pins_arduino.h for the rambo variant is missing the digitalPinToInterrupt() macro, which is now used by Marlin 3d printer firmware.  This PR adds the macro.

Mega2560-Arduino pin mapping:  https://www.arduino.cc/en/Hacking/PinMapping2560

Ultimachine devs - @johnnyr, @kakaroto, @sjkelly - may want to review this and/or incorporate it in their official pins_arduino.h.