### PR TITLE
Cleared warnings on platformio for Arduino Uno

### DIFF
--- a/libraries/WiFi/src/utility/spi_drv.h
+++ b/libraries/WiFi/src/utility/spi_drv.h
@@ -38,8 +38,6 @@
 	SpiDrv::waitForSlaveReady();  \
 	SpiDrv::spiSlaveSelect();
 
-static bool initialized = false;
-
 class SpiDrv
 {
 private:

--- a/libraries/WiFi/src/utility/wifi_drv.cpp
+++ b/libraries/WiFi/src/utility/wifi_drv.cpp
@@ -448,7 +448,7 @@ char* WiFiDrv::getSSIDNetoworks(uint8_t networkItem)
 uint8_t WiFiDrv::getEncTypeNetowrks(uint8_t networkItem)
 {
 	if (networkItem >= WL_NETWORKS_LIST_MAXNUM)
-		return NULL;
+		return 0;
 
 	WAIT_FOR_SLAVE_SELECT();
 
@@ -473,7 +473,8 @@ uint8_t WiFiDrv::getEncTypeNetowrks(uint8_t networkItem)
 int32_t WiFiDrv::getRSSINetoworks(uint8_t networkItem)
 {
 	if (networkItem >= WL_NETWORKS_LIST_MAXNUM)
-		return NULL;
+		return 0;
+	
 	int32_t	networkRssi = 0;
 
 	WAIT_FOR_SLAVE_SELECT();


### PR DESCRIPTION
Cleared warnings on platformio for Arduino Uno

.platformio\packages\framework-arduinoavr\libraries\WiFi\src\utility\wifi_drv.cpp: In static member function 'static uint8_t WiFiDrv::getEncTypeNetowrks(uint8_t)':
C:\Users\chris\.platformio\packages\framework-arduinoavr\libraries\WiFi\src\utility\wifi_drv.cpp:451:10: warning: converting to non-pointer type 'uint8_t {aka unsigned char}' from NULL [-Wconversion-null]
return NULL;
^
....\.platformio\packages\framework-arduinoavr\libraries\WiFi\src\utility\wifi_drv.cpp: In static member function 'static int32_t WiFiDrv::getRSSINetoworks(uint8_t)':
....\.platformio\packages\framework-arduinoavr\libraries\WiFi\src\utility\wifi_drv.cpp:476:10: warning: converting to non-pointer type 'int32_t {aka long int}' from NULL [-Wconversion-null]
return NULL;
^

...\.platformio\packages\framework-arduinoavr\libraries\WiFi\src\utility\spi_drv.cpp:22:0:
C:\Users\chris\.platformio\packages\framework-arduinoavr\libraries\WiFi\src/utility/spi_drv.h:41:13: warning: 'initialized' defined but not used [-Wunused-variable]
static bool initialized = false;
^
Verified
